### PR TITLE
fix: update ReadMe during release process. Issue #2

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "oclif-dev manifest && oclif-dev readme",
-    "version": "oclif-dev readme && git add README.md && git commit -m \"chore: version update in ReadMe\" && changeset version",
+    "version": "oclif-dev readme && git add README.md && git commit -m \"chore: version update in readme\" && changeset version",
     "changeset": "changeset",
     "create-version": "changeset version",
     "release": "changeset publish",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "scripts": {
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "oclif-dev manifest && oclif-dev readme",
-    "version": "oclif-dev readme && git add README.md && changeset version",
+    "version": "oclif-dev readme && git add README.md && git commit -m \"chore: version update in ReadMe\" && changeset version",
     "changeset": "changeset",
     "create-version": "changeset version",
     "release": "changeset publish",


### PR DESCRIPTION
Right now when the npm run version is executed by the GitHub Actions flow on merge to main it does not commit the actual README.md changes generated by oclif-dev readme. This is primarily a problem since the README.md file contains links that make use of the version tag meaning those will be outdated.